### PR TITLE
fix: support freebuff waiting room sessions

### DIFF
--- a/config.go
+++ b/config.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -58,7 +59,7 @@ func loadConfig(configPath string) (Config, error) {
 
 	finalCfg := Config{
 		ListenAddr:       strings.TrimSpace(cfg.ListenAddr),
-		UpstreamBaseURL:  strings.TrimRight(strings.TrimSpace(cfg.UpstreamBaseURL), "/"),
+		UpstreamBaseURL:  normalizeUpstreamBaseURL(cfg.UpstreamBaseURL),
 		AuthTokens:       dedupeStrings(cfg.AuthTokens),
 		RotationInterval: rotationInterval,
 		RequestTimeout:   requestTimeout,
@@ -88,7 +89,7 @@ func loadConfig(configPath string) (Config, error) {
 func loadRawConfig(configPath string) (rawConfig, error) {
 	cfg := rawConfig{
 		ListenAddr:       ":8080",
-		UpstreamBaseURL:  "https://codebuff.com",
+		UpstreamBaseURL:  "https://www.codebuff.com",
 		RotationInterval: "6h",
 		RequestTimeout:   "15m",
 	}
@@ -154,6 +155,22 @@ func dedupeStrings(values []string) []string {
 		out = append(out, value)
 	}
 	return out
+}
+
+func normalizeUpstreamBaseURL(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return raw
+	}
+
+	parsed, err := url.Parse(raw)
+	if err != nil {
+		return strings.TrimRight(raw, "/")
+	}
+	if strings.EqualFold(parsed.Host, "codebuff.com") {
+		parsed.Host = "www.codebuff.com"
+	}
+	return strings.TrimRight(parsed.String(), "/")
 }
 
 func containsString(values []string, needle string) bool {

--- a/run_manager.go
+++ b/run_manager.go
@@ -33,6 +33,10 @@ type tokenPool struct {
 	draining      []*managedRun
 	lastError     string
 	cooldownUntil time.Time
+	sessionStatus string
+	sessionID     string
+	sessionPollAt time.Time
+	sessionExpiry time.Time
 }
 
 type managedRun struct {
@@ -45,8 +49,9 @@ type managedRun struct {
 }
 
 type runLease struct {
-	pool *tokenPool
-	run  *managedRun
+	pool               *tokenPool
+	run                *managedRun
+	freebuffInstanceID string
 }
 
 type tokenSnapshot struct {
@@ -189,6 +194,11 @@ func (m *RunManager) Snapshots() []tokenSnapshot {
 }
 
 func (p *tokenPool) acquire(ctx context.Context, agentID string) (*runLease, error) {
+	instanceID, err := p.ensureSessionReady(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	p.mu.Lock()
 	if now := time.Now(); now.Before(p.cooldownUntil) {
 		cooldownUntil := p.cooldownUntil
@@ -213,7 +223,7 @@ func (p *tokenPool) acquire(ctx context.Context, agentID string) (*runLease, err
 	}
 	run.inflight++
 	run.requestCount++
-	return &runLease{pool: p, run: run}, nil
+	return &runLease{pool: p, run: run, freebuffInstanceID: instanceID}, nil
 }
 
 func (p *tokenPool) maintain(ctx context.Context) error {
@@ -390,6 +400,129 @@ func (p *tokenPool) markCooldown(duration time.Duration, reason string) {
 	}
 }
 
+func (p *tokenPool) invalidateSession(reason string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.sessionStatus = ""
+	p.sessionID = ""
+	p.sessionPollAt = time.Time{}
+	p.sessionExpiry = time.Time{}
+	if reason != "" {
+		p.lastError = reason
+	}
+}
+
+func (p *tokenPool) ensureSessionReady(ctx context.Context) (string, error) {
+	for {
+		p.mu.Lock()
+		status := p.sessionStatus
+		instanceID := p.sessionID
+		pollAt := p.sessionPollAt
+		expiry := p.sessionExpiry
+		p.mu.Unlock()
+
+		if status == "disabled" {
+			return "", nil
+		}
+		if status == "active" && strings.TrimSpace(instanceID) != "" {
+			if expiry.IsZero() || time.Now().Before(expiry.Add(-5*time.Second)) {
+				return instanceID, nil
+			}
+		}
+
+		if !pollAt.IsZero() && time.Now().Before(pollAt) {
+			waitFor := time.Until(pollAt)
+			timer := time.NewTimer(waitFor)
+			select {
+			case <-ctx.Done():
+				timer.Stop()
+				return "", ctx.Err()
+			case <-timer.C:
+			}
+		}
+
+		var (
+			state *FreeSessionState
+			err   error
+		)
+		if strings.TrimSpace(instanceID) != "" && (status == "queued" || status == "active") {
+			state, err = p.client.GetFreeSession(ctx, p.token, instanceID)
+		} else {
+			state, err = p.client.PostFreeSession(ctx, p.token)
+		}
+		if err != nil {
+			p.mu.Lock()
+			p.lastError = err.Error()
+			p.sessionPollAt = time.Now().Add(5 * time.Second)
+			p.mu.Unlock()
+			return "", err
+		}
+
+		ready, nextInstanceID, delay := p.applyFreeSessionState(state)
+		if ready {
+			return nextInstanceID, nil
+		}
+
+		if delay <= 0 {
+			delay = time.Second
+		}
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			return "", ctx.Err()
+		case <-timer.C:
+		}
+	}
+}
+
+func (p *tokenPool) applyFreeSessionState(state *FreeSessionState) (bool, string, time.Duration) {
+	if state == nil {
+		return false, "", time.Second
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.sessionStatus = strings.TrimSpace(state.Status)
+	p.sessionID = strings.TrimSpace(state.InstanceID)
+	p.sessionPollAt = time.Time{}
+	p.sessionExpiry = state.ExpiresAt
+	p.lastError = ""
+
+	switch p.sessionStatus {
+	case "disabled":
+		p.sessionID = ""
+		return true, "", 0
+	case "active":
+		if p.sessionID == "" {
+			p.lastError = "free session active response missing instance id"
+			return false, "", time.Second
+		}
+		return true, p.sessionID, 0
+	case "queued":
+		delay := time.Duration(state.EstimatedWaitMs) * time.Millisecond
+		if delay < time.Second {
+			delay = time.Second
+		}
+		if delay > 15*time.Second {
+			delay = 15 * time.Second
+		}
+		p.sessionPollAt = time.Now().Add(delay)
+		p.lastError = fmt.Sprintf("freebuff waiting room queued (position %d/%d)", maxInt(state.Position, 1), maxInt(state.QueueDepth, maxInt(state.Position, 1)))
+		return false, "", delay
+	case "none", "ended", "superseded":
+		return false, "", 0
+	default:
+		if state.Message != "" {
+			p.lastError = state.Message
+		} else {
+			p.lastError = "unexpected free session status: " + p.sessionStatus
+		}
+		return false, "", time.Second
+	}
+}
+
 func (p *tokenPool) snapshot() tokenSnapshot {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -410,4 +543,11 @@ func (p *tokenPool) snapshot() tokenSnapshot {
 		})
 	}
 	return snapshot
+}
+
+func maxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
 }

--- a/server.go
+++ b/server.go
@@ -157,7 +157,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 
 		s.logger.Printf("[%s] Routing request (model: %s) via run: %s", lease.pool.name, requestedModel, lease.run.id)
 
-		upstreamBody, err := s.injectUpstreamMetadata(payload, requestedModel, lease.run.id)
+		upstreamBody, err := s.injectUpstreamMetadata(payload, requestedModel, lease.run.id, lease.freebuffInstanceID)
 		if err != nil {
 			s.runs.Release(lease)
 			writeOpenAIError(w, http.StatusBadRequest, err.Error(), "invalid_request_error", "")
@@ -190,6 +190,13 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 
+		if isSessionInvalid(resp.StatusCode, errorBody) {
+			s.logger.Printf("%s: free session invalid, refreshing and retrying", lease.pool.name)
+			lease.pool.invalidateSession(strings.TrimSpace(string(errorBody)))
+			s.runs.Release(lease)
+			continue
+		}
+
 		if resp.StatusCode == http.StatusUnauthorized {
 			s.runs.Cooldown(lease, 30*time.Minute, "upstream auth rejected token")
 		}
@@ -203,7 +210,7 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	writeOpenAIError(w, http.StatusBadGateway, "upstream run expired twice in a row", "server_error", "")
 }
 
-func (s *Server) injectUpstreamMetadata(payload map[string]any, requestedModel, runID string) ([]byte, error) {
+func (s *Server) injectUpstreamMetadata(payload map[string]any, requestedModel, runID, freebuffInstanceID string) ([]byte, error) {
 	cloned := cloneMap(payload)
 	cloned["model"] = requestedModel
 
@@ -221,6 +228,9 @@ func (s *Server) injectUpstreamMetadata(payload map[string]any, requestedModel, 
 	metadata["run_id"] = runID
 	metadata["cost_mode"] = "free"
 	metadata["client_id"] = generateClientSessionId()
+	if strings.TrimSpace(freebuffInstanceID) != "" {
+		metadata["freebuff_instance_id"] = strings.TrimSpace(freebuffInstanceID)
+	}
 	cloned["codebuff_metadata"] = metadata
 
 	body, err := json.Marshal(cloned)
@@ -553,6 +563,22 @@ func isRunInvalid(statusCode int, body []byte) bool {
 	}
 	message := strings.ToLower(string(body))
 	return strings.Contains(message, "runid not found") || strings.Contains(message, "runid not running")
+}
+
+func isSessionInvalid(statusCode int, body []byte) bool {
+	switch statusCode {
+	case 409, 410, 426, 428, 429:
+	default:
+		return false
+	}
+
+	_, _, code := extractUpstreamError(bytes.TrimSpace(body))
+	switch code {
+	case "freebuff_update_required", "waiting_room_required", "waiting_room_queued", "session_superseded", "session_expired":
+		return true
+	default:
+		return false
+	}
 }
 
 func writePassthroughError(w http.ResponseWriter, statusCode int, body []byte) {

--- a/upstream.go
+++ b/upstream.go
@@ -19,6 +19,19 @@ type UpstreamClient struct {
 	userAgent  string
 }
 
+type FreeSessionState struct {
+	Status                 string    `json:"status"`
+	InstanceID             string    `json:"instanceId"`
+	Position               int       `json:"position"`
+	QueueDepth             int       `json:"queueDepth"`
+	EstimatedWaitMs        int64     `json:"estimatedWaitMs"`
+	RemainingMs            int64     `json:"remainingMs"`
+	ExpiresAt              time.Time `json:"expiresAt"`
+	GracePeriodEndsAt      time.Time `json:"gracePeriodEndsAt"`
+	GracePeriodRemainingMs int64     `json:"gracePeriodRemainingMs"`
+	Message                string    `json:"message"`
+}
+
 func NewUpstreamClient(cfg Config) *UpstreamClient {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	if cfg.HTTPProxy != "" {
@@ -122,6 +135,14 @@ func (c *UpstreamClient) ChatCompletions(ctx context.Context, authToken string, 
 	return resp, responseBody, nil
 }
 
+func (c *UpstreamClient) PostFreeSession(ctx context.Context, authToken string) (*FreeSessionState, error) {
+	return c.doFreeSession(ctx, http.MethodPost, authToken, "")
+}
+
+func (c *UpstreamClient) GetFreeSession(ctx context.Context, authToken, instanceID string) (*FreeSessionState, error) {
+	return c.doFreeSession(ctx, http.MethodGet, authToken, instanceID)
+}
+
 func (c *UpstreamClient) doJSON(ctx context.Context, authToken, path string, body []byte) (*http.Response, error) {
 	requestURL, err := url.JoinPath(c.baseURL, path)
 	if err != nil {
@@ -142,6 +163,44 @@ func (c *UpstreamClient) doJSON(ctx context.Context, authToken, path string, bod
 		return nil, fmt.Errorf("send upstream request: %w", err)
 	}
 	return resp, nil
+}
+
+func (c *UpstreamClient) doFreeSession(ctx context.Context, method, authToken, instanceID string) (*FreeSessionState, error) {
+	requestURL, err := url.JoinPath(c.baseURL, "/api/v1/freebuff/session")
+	if err != nil {
+		return nil, fmt.Errorf("build free session url: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, requestURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create free session request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+authToken)
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", c.userAgent)
+	if method == http.MethodGet && strings.TrimSpace(instanceID) != "" {
+		req.Header.Set("X-Freebuff-Instance-Id", strings.TrimSpace(instanceID))
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("send free session request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read free session response: %w", err)
+	}
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("free session %s failed with status %d: %s", method, resp.StatusCode, strings.TrimSpace(string(responseBody)))
+	}
+
+	var parsed FreeSessionState
+	if err := json.Unmarshal(responseBody, &parsed); err != nil {
+		return nil, fmt.Errorf("decode free session response: %w", err)
+	}
+	return &parsed, nil
 }
 
 func retryAfterDuration(headerValue string) time.Duration {


### PR DESCRIPTION
## Summary

This fixes `freebuff_update_required` errors caused by the new Freebuff waiting-room flow.

The proxy previously behaved like a pre-waiting-room client:
- it did not create a Freebuff session via `POST /api/v1/freebuff/session`
- it did not include `codebuff_metadata.freebuff_instance_id` on chat requests
- it still defaulted to `https://codebuff.com`, which now redirects to `https://www.codebuff.com`

This change updates the proxy to follow the current upstream contract.

## Changes

- normalize the upstream base URL to `https://www.codebuff.com`
- add Freebuff session API support in the upstream client
- track per-token waiting-room session state in the run manager
- block request routing until a token has an active Freebuff session
- inject `codebuff_metadata.freebuff_instance_id` into upstream chat requests
- treat waiting-room related upstream errors as retryable session invalidation signals

## Why

Upstream now returns `426 freebuff_update_required` when free-mode chat requests do not include a valid `freebuff_instance_id`. Without session handling, the proxy is rejected even when auth tokens are otherwise valid.

## Validation

Verified against a live deployment:
- `minimax/minimax-m2.7` chat completions returned successfully
- `google/gemini-3.1-flash-lite-preview` chat completions returned successfully
- the previous `freebuff_update_required` failure no longer reproduces

## Notes

This keeps the existing run rotation model intact while adding the waiting-room session lifecycle required by current Freebuff free-mode traffic.
