### PR TITLE
fix: fail fast while free session is queued

### DIFF
--- a/free_session.go
+++ b/free_session.go
@@ -13,7 +13,6 @@ import (
 )
 
 const freeSessionPollInterval = 5 * time.Second
-const freeSessionRetryDelay = 10 * time.Second
 
 type sessionStatus string
 
@@ -29,6 +28,8 @@ const (
 type freeSessionResponse struct {
 	Status                 string `json:"status"`
 	InstanceID             string `json:"instanceId"`
+	Position               int    `json:"position"`
+	QueueDepth             int    `json:"queueDepth"`
 	ExpiresAt              string `json:"expiresAt"`
 	RemainingMs            int64  `json:"remainingMs"`
 	EstimatedWaitMs        int64  `json:"estimatedWaitMs"`
@@ -40,6 +41,10 @@ type cachedSession struct {
 	status     sessionStatus
 	instanceID string
 	expiresAt  time.Time
+	position   int
+	queueDepth int
+	pollAt     time.Time
+	retryAfter time.Duration
 }
 
 func (p *tokenPool) ensureSession(ctx context.Context) (string, error) {
@@ -48,6 +53,10 @@ func (p *tokenPool) ensureSession(ctx context.Context) (string, error) {
 		if instanceID, ready := p.readySessionLocked(time.Now()); ready {
 			p.mu.Unlock()
 			return instanceID, nil
+		}
+		if waitingErr := waitingRoomErrorFromSession(p.name, p.session, time.Now()); waitingErr != nil {
+			p.mu.Unlock()
+			return "", waitingErr
 		}
 		if ch := p.sessionRefreshCh; ch != nil {
 			p.mu.Unlock()
@@ -65,50 +74,28 @@ func (p *tokenPool) ensureSession(ctx context.Context) (string, error) {
 		session, instanceID, err := p.refreshSession(ctx)
 
 		p.mu.Lock()
+		if session != nil {
+			p.session = session
+		}
 		if err != nil {
 			p.session = nil
 			p.lastError = err.Error()
+		} else if waitingErr := waitingRoomErrorFromSession(p.name, session, time.Now()); waitingErr != nil {
+			p.lastError = waitingErr.Error()
 		} else {
-			p.session = session
 			p.lastError = ""
 		}
 		close(p.sessionRefreshCh)
 		p.sessionRefreshCh = nil
 		p.mu.Unlock()
 
-		if err == nil && session != nil && session.status == sessionStatusActive {
-			p.watchSessionExpiry(session.instanceID, session.expiresAt)
+		if err == nil {
+			if waitingErr := waitingRoomErrorFromSession(p.name, session, time.Now()); waitingErr != nil {
+				return "", waitingErr
+			}
 		}
-
 		return instanceID, err
 	}
-}
-
-func (p *tokenPool) ensureSessionAsync(reason string) {
-	p.mu.Lock()
-	if now := time.Now(); now.Before(p.cooldownUntil) {
-		p.mu.Unlock()
-		return
-	}
-	if p.sessionRefreshCh != nil || p.sessionRebuildScheduled {
-		p.mu.Unlock()
-		return
-	}
-	p.sessionRebuildScheduled = true
-	p.mu.Unlock()
-
-	go func() {
-		defer func() {
-			p.mu.Lock()
-			p.sessionRebuildScheduled = false
-			p.mu.Unlock()
-		}()
-
-		if reason != "" {
-			p.logger.Printf("%s: rebuilding free session in background (%s)", p.name, reason)
-		}
-		p.prewarmSession(context.Background())
-	}()
 }
 
 func (p *tokenPool) readySessionLocked(now time.Time) (string, bool) {
@@ -129,17 +116,25 @@ func (p *tokenPool) readySessionLocked(now time.Time) (string, bool) {
 	return "", false
 }
 
-func (p *tokenPool) hasReadySession() bool {
-	p.mu.Lock()
-	defer p.mu.Unlock()
-	_, ready := p.readySessionLocked(time.Now())
-	return ready
-}
-
 func (p *tokenPool) refreshSession(ctx context.Context) (*cachedSession, string, error) {
-	state, err := p.client.CreateOrRefreshSession(ctx, p.token)
-	if err != nil {
-		return nil, "", fmt.Errorf("start free session: %w", err)
+	p.mu.Lock()
+	current := p.session
+	p.mu.Unlock()
+
+	var (
+		state freeSessionResponse
+		err   error
+	)
+	if current != nil && current.status == sessionStatusQueued && strings.TrimSpace(current.instanceID) != "" {
+		state, err = p.client.GetSession(ctx, p.token, current.instanceID)
+		if err != nil {
+			return nil, "", fmt.Errorf("poll free session: %w", err)
+		}
+	} else {
+		state, err = p.client.CreateOrRefreshSession(ctx, p.token)
+		if err != nil {
+			return nil, "", fmt.Errorf("start free session: %w", err)
+		}
 	}
 
 	for {
@@ -165,13 +160,15 @@ func (p *tokenPool) refreshSession(ctx context.Context) (*cachedSession, string,
 			if instanceID == "" {
 				return nil, "", fmt.Errorf("free session queued response missing instanceId")
 			}
-			if err := sleepWithContext(ctx, queuedPollDelay(state)); err != nil {
-				return nil, "", err
-			}
-			state, err = p.client.GetSession(ctx, p.token, instanceID)
-			if err != nil {
-				return nil, "", fmt.Errorf("poll free session: %w", err)
-			}
+			delay := queuedPollDelay(state)
+			return &cachedSession{
+				status:     sessionStatusQueued,
+				instanceID: instanceID,
+				position:   maxInt(state.Position, 1),
+				queueDepth: maxInt(state.QueueDepth, maxInt(state.Position, 1)),
+				pollAt:     time.Now().Add(delay),
+				retryAfter: delay,
+			}, "", nil
 		case sessionStatusNone, sessionStatusEnded, sessionStatusSuperseded:
 			state, err = p.client.CreateOrRefreshSession(ctx, p.token)
 			if err != nil {
@@ -185,13 +182,11 @@ func (p *tokenPool) refreshSession(ctx context.Context) (*cachedSession, string,
 
 func (p *tokenPool) invalidateSession(reason string) {
 	p.mu.Lock()
+	defer p.mu.Unlock()
 	p.session = nil
 	if reason != "" {
 		p.lastError = reason
 	}
-	p.mu.Unlock()
-
-	p.ensureSessionAsync(reason)
 }
 
 func (p *tokenPool) currentSessionInstanceID() string {
@@ -203,65 +198,26 @@ func (p *tokenPool) currentSessionInstanceID() string {
 	return p.session.instanceID
 }
 
-func (p *tokenPool) prewarmSession(ctx context.Context) {
-	for {
-		if _, err := p.ensureSession(ctx); err == nil {
-			return
-		} else {
-			p.logger.Printf("%s: session prewarm failed: %v", p.name, err)
-		}
-
-		if err := sleepWithContext(ctx, freeSessionRetryDelay); err != nil {
-			return
+func waitingRoomErrorFromSession(token string, session *cachedSession, now time.Time) *waitingRoomError {
+	if session == nil || session.status != sessionStatusQueued {
+		return nil
+	}
+	if !session.pollAt.IsZero() && now.Before(session.pollAt) {
+		return &waitingRoomError{
+			Token:      token,
+			Position:   session.position,
+			QueueDepth: session.queueDepth,
+			RetryAfter: time.Until(session.pollAt),
 		}
 	}
+	return nil
 }
 
-func (p *tokenPool) watchSessionExpiry(instanceID string, expiresAt time.Time) {
-	if instanceID == "" || expiresAt.IsZero() {
-		return
+func maxInt(a, b int) int {
+	if a > b {
+		return a
 	}
-
-	go func() {
-		if err := sleepWithContext(context.Background(), time.Until(expiresAt.Add(time.Second))); err != nil {
-			return
-		}
-
-		for {
-			p.mu.Lock()
-			current := p.session
-			if current == nil || current.status != sessionStatusActive || current.instanceID != instanceID {
-				p.mu.Unlock()
-				return
-			}
-			if p.hasInflightRequestsLocked() {
-				p.mu.Unlock()
-				if err := sleepWithContext(context.Background(), time.Second); err != nil {
-					return
-				}
-				continue
-			}
-			p.session = nil
-			p.mu.Unlock()
-
-			p.ensureSessionAsync("expired")
-			return
-		}
-	}()
-}
-
-func (p *tokenPool) hasInflightRequestsLocked() bool {
-	for _, run := range p.runs {
-		if run != nil && run.inflight > 0 {
-			return true
-		}
-	}
-	for _, run := range p.draining {
-		if run != nil && run.inflight > 0 {
-			return true
-		}
-	}
-	return false
+	return b
 }
 
 func (p *tokenPool) endSession(ctx context.Context) error {

--- a/run_manager.go
+++ b/run_manager.go
@@ -33,7 +33,6 @@ type tokenPool struct {
 	draining      []*managedRun
 	session       *cachedSession
 	sessionRefreshCh chan struct{}
-	sessionRebuildScheduled bool
 	lastError     string
 	cooldownUntil time.Time
 }
@@ -58,7 +57,10 @@ type tokenSnapshot struct {
 	DrainingRuns  int           `json:"draining_runs"`
 	SessionStatus string        `json:"session_status,omitempty"`
 	SessionInstanceID string    `json:"session_instance_id,omitempty"`
-	SessionExpiresAt time.Time  `json:"session_expires_at,omitempty"`
+	SessionExpiresAt  time.Time `json:"session_expires_at,omitempty"`
+	SessionPosition   int       `json:"session_position,omitempty"`
+	SessionQueueDepth int       `json:"session_queue_depth,omitempty"`
+	SessionPollAt     time.Time `json:"session_poll_at,omitempty"`
 	CooldownUntil time.Time    `json:"cooldown_until,omitempty"`
 	LastError     string        `json:"last_error,omitempty"`
 }
@@ -69,6 +71,35 @@ type runSnapshot struct {
 	StartedAt    time.Time `json:"started_at"`
 	Inflight     int       `json:"inflight"`
 	RequestCount int       `json:"request_count"`
+}
+
+type waitingRoomError struct {
+	Token      string
+	Position   int
+	QueueDepth int
+	RetryAfter time.Duration
+}
+
+func (e *waitingRoomError) Error() string {
+	if e == nil {
+		return "freebuff waiting room queued"
+	}
+
+	message := "freebuff waiting room queued"
+	if e.Token != "" {
+		message += " for " + e.Token
+	}
+	if e.Position > 0 {
+		if e.QueueDepth >= e.Position {
+			message += fmt.Sprintf(" (position %d/%d)", e.Position, e.QueueDepth)
+		} else {
+			message += fmt.Sprintf(" (position %d)", e.Position)
+		}
+	}
+	if e.RetryAfter > 0 {
+		message += fmt.Sprintf(", retry in about %s", e.RetryAfter.Round(time.Second))
+	}
+	return message
 }
 
 func NewRunManager(cfg Config, client *UpstreamClient, logger *log.Logger) *RunManager {
@@ -96,7 +127,7 @@ func (m *RunManager) Start(ctx context.Context, agentIDs []string) {
 	// Pre-warm runs for all free agents in background.
 	// The server is already listening; if a request arrives before
 	// pre-warming finishes, acquire() will lazily create the run.
-	go m.prewarm(ctx, agentIDs)
+	go m.prewarm(agentIDs)
 
 	m.wg.Add(1)
 	go func() {
@@ -121,14 +152,16 @@ func (m *RunManager) Start(ctx context.Context, agentIDs []string) {
 	}()
 }
 
-func (m *RunManager) prewarm(ctx context.Context, agentIDs []string) {
-	startupCtx, cancel := context.WithTimeout(context.Background(), m.cfg.RequestTimeout)
+func (m *RunManager) prewarm(agentIDs []string) {
+	ctx, cancel := context.WithTimeout(context.Background(), m.cfg.RequestTimeout)
 	defer cancel()
 
 	for _, pool := range m.pools {
-		go pool.prewarmSession(ctx)
+		if _, err := pool.ensureSession(ctx); err != nil {
+			m.logger.Printf("%s: free session prewarm failed: %v", pool.name, err)
+		}
 		for _, agentID := range agentIDs {
-			if err := pool.rotateAgent(startupCtx, agentID); err != nil {
+			if err := pool.rotateAgent(ctx, agentID); err != nil {
 				m.logger.Printf("%s: prewarm %s failed: %v", pool.name, agentID, err)
 			} else {
 				m.logger.Printf("%s: prewarmed %s", pool.name, agentID)
@@ -153,28 +186,31 @@ func (m *RunManager) Acquire(ctx context.Context, agentID string) (*runLease, er
 	}
 
 	startIndex := int(m.next.Add(1)-1) % len(m.pools)
-	candidates := make([]*tokenPool, 0, len(m.pools))
-	for pass := 0; pass < 2; pass++ {
-		for offset := 0; offset < len(m.pools); offset++ {
-			pool := m.pools[(startIndex+offset)%len(m.pools)]
-			ready := pool.hasReadySession()
-			if pass == 0 && !ready {
-				continue
-			}
-			if pass == 1 && ready {
-				continue
-			}
-			candidates = append(candidates, pool)
-		}
-	}
-
 	var errs []string
-	for _, pool := range candidates {
+	var waiting []*waitingRoomError
+	for offset := 0; offset < len(m.pools); offset++ {
+		pool := m.pools[(startIndex+offset)%len(m.pools)]
 		lease, err := pool.acquire(ctx, agentID)
 		if err == nil {
 			return lease, nil
 		}
+		var waitingErr *waitingRoomError
+		if errors.As(err, &waitingErr) {
+			waiting = append(waiting, waitingErr)
+		}
 		errs = append(errs, fmt.Sprintf("%s: %v", pool.name, err))
+	}
+
+	if len(waiting) == len(m.pools) && len(waiting) > 0 {
+		best := waiting[0]
+		for _, candidate := range waiting[1:] {
+			if candidate != nil && (best == nil || (candidate.Position > 0 && candidate.Position < best.Position)) {
+				best = candidate
+			}
+		}
+		if best != nil {
+			return nil, best
+		}
 	}
 
 	return nil, fmt.Errorf("unable to acquire run from any token (%s)", strings.Join(errs, "; "))
@@ -242,6 +278,10 @@ func (p *tokenPool) acquire(ctx context.Context, agentID string) (*runLease, err
 }
 
 func (p *tokenPool) maintain(ctx context.Context) error {
+	if _, err := p.ensureSession(ctx); err != nil {
+		p.logger.Printf("%s: refresh free session failed: %v", p.name, err)
+	}
+
 	p.mu.Lock()
 	var toRotate []string
 	for agentID, run := range p.runs {
@@ -423,15 +463,18 @@ func (p *tokenPool) snapshot() tokenSnapshot {
 	defer p.mu.Unlock()
 
 	snapshot := tokenSnapshot{
-		Name:          p.name,
-		DrainingRuns:  len(p.draining),
-		CooldownUntil: p.cooldownUntil,
-		LastError:     p.lastError,
+		Name:             p.name,
+		DrainingRuns:     len(p.draining),
+		CooldownUntil:    p.cooldownUntil,
+		LastError:        p.lastError,
 	}
 	if p.session != nil {
 		snapshot.SessionStatus = string(p.session.status)
 		snapshot.SessionInstanceID = p.session.instanceID
 		snapshot.SessionExpiresAt = p.session.expiresAt
+		snapshot.SessionPosition = p.session.position
+		snapshot.SessionQueueDepth = p.session.queueDepth
+		snapshot.SessionPollAt = p.session.pollAt
 	}
 	for agentID, run := range p.runs {
 		snapshot.Runs = append(snapshot.Runs, runSnapshot{

--- a/server.go
+++ b/server.go
@@ -151,13 +151,36 @@ func (s *Server) handleChatCompletions(w http.ResponseWriter, r *http.Request) {
 	for attempt := 0; attempt < 2; attempt++ {
 		lease, err := s.runs.Acquire(r.Context(), agentID)
 		if err != nil {
+			var waitingErr *waitingRoomError
+			if errors.As(err, &waitingErr) {
+				if waitingErr.RetryAfter > 0 {
+					w.Header().Set("Retry-After", fmt.Sprintf("%.0f", waitingErr.RetryAfter.Seconds()))
+				}
+				writeOpenAIError(w, http.StatusServiceUnavailable, waitingErr.Error(), "server_error", "waiting_room_queued")
+				return
+			}
 			writeOpenAIError(w, http.StatusBadGateway, "no healthy upstream auth token available", "server_error", "")
 			return
 		}
 
 		s.logger.Printf("[%s] Routing request (model: %s) via run: %s", lease.pool.name, requestedModel, lease.run.id)
 
-		upstreamBody, err := s.injectUpstreamMetadata(payload, requestedModel, lease.run.id, lease.pool.currentSessionInstanceID())
+		sessionInstanceID, err := lease.pool.ensureSession(r.Context())
+		if err != nil {
+			s.runs.Release(lease)
+			var waitingErr *waitingRoomError
+			if errors.As(err, &waitingErr) {
+				if waitingErr.RetryAfter > 0 {
+					w.Header().Set("Retry-After", fmt.Sprintf("%.0f", waitingErr.RetryAfter.Seconds()))
+				}
+				writeOpenAIError(w, http.StatusServiceUnavailable, waitingErr.Error(), "server_error", "waiting_room_queued")
+				return
+			}
+			writeOpenAIError(w, http.StatusBadGateway, "failed to acquire upstream free session", "server_error", "")
+			return
+		}
+
+		upstreamBody, err := s.injectUpstreamMetadata(payload, requestedModel, lease.run.id, sessionInstanceID)
 		if err != nil {
 			s.runs.Release(lease)
 			writeOpenAIError(w, http.StatusBadRequest, err.Error(), "invalid_request_error", "")


### PR DESCRIPTION
## Summary

This fixes a regression where chat requests could hang for a long time with no data and no error while every auth token was still queued in the Freebuff waiting room.

The current flow waits inside free session acquisition until a session becomes active. When all tokens are queued, the request can sit open for a long time instead of returning a clear retry signal.

## Changes

- prewarm free sessions during startup so tokens join the waiting room before the first user request
- refresh free sessions during background maintenance instead of only on demand
- preserve queued session state and poll timing in the session cache
- return a structured `waiting_room_queued` error with `503` and `Retry-After` instead of hanging the request
- expose queue position, queue depth, and next poll time in `/healthz`

## Why

Without this change, the proxy can appear broken even though upstream is just queueing the token. Failing fast gives clients a deterministic response and makes queue state observable.

## Validation

Verified on a live deployment after rebuilding from source:

- the previously hanging `POST /v1/chat/completions` path stopped hanging indefinitely
- when a token was still queued, the service returned a clear waiting-room response instead of blocking
- once a token became active, `minimax/minimax-m2.7` chat completions returned successfully through `https://freebuff.etunnel.cc.cd/v1/chat/completions`
- `/healthz` showed session status and queue metadata for each token